### PR TITLE
Replace nginx with traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,15 @@ services:
     volumes:
       - mongo-data:/data/db
 
-  nginx:
-    image: nginx:latest
+  traefik:
+    image: traefik:v2.10
     ports:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic.toml:/etc/traefik/dynamic.toml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
       - app
 

--- a/traefik/dynamic.toml
+++ b/traefik/dynamic.toml
@@ -1,0 +1,28 @@
+[http.routers.redirect-root]
+  rule = "Host(`structana.com`) || Host(`funemployed.tools`) || Host(`cosmicauracle.com`)"
+  middlewares = ["to-www"]
+  entryPoints = ["web", "websecure"]
+  service = "noop"
+
+[http.routers.py-hello]
+  rule = "Host(`test.structana.com`) && Path(`/api/py/hello`)"
+  entryPoints = ["web", "websecure"]
+  service = "app"
+
+[http.routers.js-hello]
+  rule = "Host(`test.structana.com`) && Path(`/api/js/hello`)"
+  entryPoints = ["web", "websecure"]
+  service = "app"
+
+[http.middlewares.to-www.redirectRegex]
+  regex = "^https?://(structana\\.com|funemployed\\.tools|cosmicauracle\\.com)(.*)"
+  replacement = "https://www.$1$2"
+  permanent = true
+
+[http.services.noop.loadBalancer]
+  [[http.services.noop.loadBalancer.servers]]
+    url = "http://0.0.0.0"
+
+[http.services.app.loadBalancer]
+  [[http.services.app.loadBalancer.servers]]
+    url = "http://app:3000"

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,8 @@
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+providers:
+  file:
+    filename: /etc/traefik/dynamic.toml


### PR DESCRIPTION
## Summary
- switch proxy from nginx to traefik
- add static entrypoint configuration in `traefik.yml`
- define redirect and route rules in `dynamic.toml`

## Testing
- `docker-compose` *(fails: command not found)*