### PR TITLE
Serve static subdomains with Traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     volumes:
       - ./app:/app
     command: sh -c "npm install && npm start"
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
     depends_on:
       - mongo
 
@@ -17,13 +17,18 @@ services:
     volumes:
       - mongo-data:/data/db
 
-  nginx:
-    image: nginx:latest
+  traefik:
+    image: traefik:v2.9
+    command:
+      - --providers.file.directory=/etc/traefik
+      - --entrypoints.web.address=:80
     ports:
       - "80:80"
-      - "443:443"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
+      - ./www:/srv/www:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - app
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,9 +1,0 @@
-events {}
-http {
-  server {
-    listen 80;
-    location / {
-      proxy_pass http://app:3000;
-    }
-  }
-}

--- a/traefik/dynamic.yml
+++ b/traefik/dynamic.yml
@@ -1,0 +1,54 @@
+http:
+  routers:
+    structana:
+      rule: Host(`www.structana.com`)
+      service: structana-files
+    structana-root:
+      rule: Host(`structana.com`)
+      middlewares:
+        - structana-redirect
+      service: noop@internal
+    cosmicauracle:
+      rule: Host(`www.cosmicauracle.com`)
+      service: cosmicauracle-files
+    cosmicauracle-root:
+      rule: Host(`cosmicauracle.com`)
+      middlewares:
+        - cosmicauracle-redirect
+      service: noop@internal
+    funemployed:
+      rule: Host(`www.funemployed.com`)
+      service: funemployed-files
+    funemployed-root:
+      rule: Host(`funemployed.com`)
+      middlewares:
+        - funemployed-redirect
+      service: noop@internal
+
+  middlewares:
+    structana-redirect:
+      redirectRegex:
+        regex: "^https?://structana\\.com/(.*)"
+        replacement: "https://www.structana.com/$1"
+        permanent: true
+    cosmicauracle-redirect:
+      redirectRegex:
+        regex: "^https?://cosmicauracle\\.com/(.*)"
+        replacement: "https://www.cosmicauracle.com/$1"
+        permanent: true
+    funemployed-redirect:
+      redirectRegex:
+        regex: "^https?://funemployed\\.com/(.*)"
+        replacement: "https://www.funemployed.com/$1"
+        permanent: true
+
+  services:
+    structana-files:
+      fileserver:
+        root: /srv/www/structana
+    cosmicauracle-files:
+      fileserver:
+        root: /srv/www/cosmicauracle
+    funemployed-files:
+      fileserver:
+        root: /srv/www/funemployed

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,8 @@
+entryPoints:
+  web:
+    address: ":80"
+
+providers:
+  file:
+    filename: /etc/traefik/dynamic.yml
+  docker: {}

--- a/www/cosmicauracle/index.html
+++ b/www/cosmicauracle/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Cosmic Auracle</title>
+  <style>
+    body { background: #1a1a1a; color: #f0eada; font-family: sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Cosmic Auracle</h1>
+</body>
+</html>

--- a/www/funemployed/index.html
+++ b/www/funemployed/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Funemployed</title>
+  <style>
+    body { background: #1a1a1a; color: #f0eada; font-family: sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Funemployed</h1>
+</body>
+</html>

--- a/www/structana/index.html
+++ b/www/structana/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Structana</title>
+  <style>
+    body { background: #1a1a1a; color: #f0eada; font-family: sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Structana</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `www/` directories for structana, cosmicauracle and funemployed
- configure Traefik and remove nginx
- route each domain to a Traefik file-server and redirect root domains to `www.`

## Testing
- `git status --short`