### PR TITLE
Add JS backend and Traefik routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,17 @@ services:
       - "3000:3000"
     depends_on:
       - mongo
+    labels:
+      - "traefik.http.routers.app.rule=PathPrefix(`/`)"
+      - "traefik.http.services.app.loadbalancer.server.port=3000"
+
+  js-backend:
+    build: ./js-backend
+    labels:
+      - "traefik.http.routers.js-backend.rule=PathPrefix(`/api/js`)"
+      - "traefik.http.services.js-backend.loadbalancer.server.port=3000"
+    depends_on:
+      - mongo
 
   mongo:
     image: mongo:6
@@ -26,6 +37,17 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
       - app
+
+  traefik:
+    image: traefik:v2.11
+    command:
+      - --providers.docker=true
+      - --entrypoints.web.address=:80
+    ports:
+      - "8080:80"
+      - "8081:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   mongo-data:

--- a/js-backend/Dockerfile
+++ b/js-backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+CMD ["npm", "start"]

--- a/js-backend/index.js
+++ b/js-backend/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/api/js/hello', (_req, res) => {
+  res.json({ message: 'Hello from JS backend!' });
+});
+
+app.listen(port, () => {
+  console.log(`JS backend listening on port ${port}`);
+});

--- a/js-backend/package.json
+++ b/js-backend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "js-backend",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/tests/test_js_hello.sh
+++ b/tests/test_js_hello.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+# start js-backend with traefik
+docker compose up -d js-backend traefik
+trap 'docker compose down -v' EXIT
+
+# give containers time to start
+sleep 5
+
+resp=$(curl -s http://localhost:8080/api/js/hello)
+
+echo "$resp"
+
+echo "$resp" | grep -q "Hello from JS backend"


### PR DESCRIPTION
## Summary
- add minimal Express service in `js-backend`
- build `js-backend` using Node 18 Dockerfile
- start js-backend through Traefik and expose `/api/js/hello`
- provide curl-based test script
- update `docker-compose.yml` to include js-backend and Traefik services

## Testing
- `./tests/test_js_hello.sh` *(fails: `docker: command not found`)*