### PR TITLE
Add Python backend service with Traefik routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,5 +27,21 @@ services:
     depends_on:
       - app
 
+  py-backend:
+    build: ./py-backend
+    labels:
+      - "traefik.http.routers.py-backend.rule=PathPrefix(`/api/py`)"
+      - "traefik.http.services.py-backend.loadbalancer.server.port=8000"
+
+  traefik:
+    image: traefik:v2.9
+    command:
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "8080:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 volumes:
   mongo-data:

--- a/py-backend/Dockerfile
+++ b/py-backend/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11
+WORKDIR /app
+COPY main.py ./
+RUN pip install --no-cache-dir fastapi uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/py-backend/main.py
+++ b/py-backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/api/py/hello')
+async def hello():
+    return {'message': 'Hello from Python!'}

--- a/tests/test_py_hello.sh
+++ b/tests/test_py_hello.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+# Start py-backend and traefik in detached mode
+
+docker compose up -d py-backend traefik >/dev/null
+# Wait a few seconds for startup
+sleep 5
+
+# Perform request
+response=$(curl -s http://localhost:8080/api/py/hello)
+
+echo "$response"
+# Check response contains expected text
+printf "%s" "$response" | grep -q "Hello from Python"
+
+echo "Test passed"


### PR DESCRIPTION
## Summary
- implement a Python FastAPI service exposing `/api/py/hello`
- provide Dockerfile based on `python:3.11`
- add a test script using `curl`
- update docker-compose to include the Python service and Traefik proxy

## Testing
- `./tests/test_py_hello.sh` *(fails: `docker` not found)*